### PR TITLE
Add CORS headers

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1,6 +1,6 @@
 import express from "express";
 
-import { unknownEndpointHandler } from "@/src/middleware/middleware";
+import { unknownEndpointHandler, addCorsHeaders } from "@/src/middleware/middleware";
 import { requestLogger } from "@/src/middleware/morgenMiddleware";
 
 import { apiRouter } from "@/src/routes/api";
@@ -24,7 +24,7 @@ app.use(bodyParser.raw());
 app.use(express.json());
 app.use(bodyParser.text());
 app.use(requestLogger);
-//app.use(requestLogger);
+app.use(addCorsHeaders);
 
 app.use("/api", apiRouter);
 //app.use("/test", testRouter);

--- a/src/middleware/middleware.ts
+++ b/src/middleware/middleware.ts
@@ -14,4 +14,10 @@ const unknownEndpointHandler = (request: Request, response: Response) => {
 //     next();
 // };
 
-export { unknownEndpointHandler };
+const addCorsHeaders = (_request: Request, response: Response, next: NextFunction) => {
+    response.header("Access-Control-Allow-Origin", "*");
+    response.header("Access-Control-Allow-Headers", "Content-Type");
+    next();
+};
+
+export { unknownEndpointHandler, addCorsHeaders };


### PR DESCRIPTION
This allows the server to be addressed from the browser, which is needed for web-based management interfaces.