### PR TITLE
fix: stop sending DTLS to clients newer than 2026.05.13.13.07

### DIFF
--- a/src/controllers/api/loginController.ts
+++ b/src/controllers/api/loginController.ts
@@ -27,7 +27,7 @@ import { getTokenForClient, getTunablesForClient } from "../../services/tunables
 import type { AddressInfo } from "node:net";
 import gameToBuildVersion from "../../constants/gameToBuildVersion.ts";
 import { args } from "../../helpers/commandLineArguments.ts";
-import { buildLabelToVersionInt } from "../../helpers/versionHelper.ts";
+import { buildLabelToVersionInt, buildVersionToInt } from "../../helpers/versionHelper.ts";
 import gameToBuildVersionInt from "../../constants/gameToBuildVersionInt.ts";
 
 export const loginController: RequestHandler = async (request, response) => {
@@ -229,7 +229,10 @@ const createLoginResponse = (request: Request, account: IDatabaseAccountJson, bu
             //{ experiment: "quick_buy_visible", experimentGroup: "quick_buy_visible" } // Shows "quick buy" market section for MR 4+ players
         ];
     }
-    if (buildVersionInt >= gameToBuildVersionInt["30.0.0"]) {
+    if (
+        buildVersionInt >= gameToBuildVersionInt["30.0.0"] &&
+        buildVersionInt <= buildVersionToInt("2026.05.13.13.07")
+    ) {
         resp.DTLS = config.dtls ?? 0; // bit 0 enables DTLS. if enabled, additional bits can be set, e.g. bit 2 to enable logging. on live, the value is 99.
     }
     if (buildVersionInt >= gameToBuildVersionInt["31.5.0"]) {


### PR DESCRIPTION
## Summary

The login response unconditionally included the `DTLS` property for any client at or above build `30.0.0`. DTLS was removed from the login response in a build after `2026.05.13.13.07`. Newer clients (e.g. `2026.06.25.12.49`) reject the response with:

```
Sys [Error]: Unknown property: DTLS
```

and fail to log in even though the server returns `200`.

This change caps the `DTLS` field to builds in the range `[30.0.0, 2026.05.13.13.07]` (which matches the highest build currently supported by the login gate), so newer clients no longer receive the unknown property.

## Test plan
- [x] Client build `2026.06.25.12.49` can now log in (previously failed with `Unknown property: DTLS`)
- [x] Builds `<= 2026.05.13.13.07` still receive `DTLS` as before